### PR TITLE
Recap/fix line break on pdf download

### DIFF
--- a/recap/recap.py
+++ b/recap/recap.py
@@ -136,7 +136,7 @@ class RecapXBlock(XBlock, StudioEditableXBlockMixin, XBlockWithSettingsMixin):
         """
         Returns formatted answer or placeholder string
         """
-        return re.sub(r'\n+', '<br /><br />', answer) if answer else "Nothing to recap."
+        return re.sub(r'\n+', '<div><span style="color: white">|</span></div>', answer) if answer else "Nothing to recap."
 
 
     def get_answer(self, usage_key, block, field):
@@ -178,7 +178,7 @@ class RecapXBlock(XBlock, StudioEditableXBlockMixin, XBlockWithSettingsMixin):
             except Exception as e:
                 logger.warn(str(e))
 
-        block_layout = '<p class="recap_question">{}</p><p class="recap_answer">{}</p>'
+        block_layout = '<p class="recap_question">{}</p><div class="recap_answer" style="page-break-after:always">{}</div>'
         qa_str = ''.join(block_layout.format(q, self.get_display_answer(a)) for q, a in blocks)
 
         layout = self.string_html.replace('[[CONTENT]]', qa_str)

--- a/recap/static/js/src/recap_edit.js
+++ b/recap/static/js/src/recap_edit.js
@@ -51,18 +51,39 @@ function StudioEditableXBlockMixin(runtime, element) {
         if (type == 'html' && tinyMceAvailable) {
             tinyMCE.baseURL = baseUrl + "/js/vendor/tinymce/js/tinymce";
             $field.tinymce({
-                theme: 'modern',
-                skin: 'studio-tmce4',
-                height: '200px',
-                formats: { code: { inline: 'code' } },
-                codemirror: { path: "" + baseUrl + "/js/vendor" },
-                convert_urls: false,
-                plugins: "link codemirror",
-                menubar: false,
-                statusbar: false,
-                toolbar_items_size: 'small',
-                toolbar: "formatselect | styleselect | bold italic underline forecolor wrapAsCode | bullist numlist outdent indent blockquote | link unlink | code",
-                resize: "both",
+                    script_url: "" + baseUrl + "/js/vendor/tinymce/js/tinymce/tinymce.full.min.js",
+                    theme: "modern",
+                    skin: 'studio-tmce4',
+                    schema: "html5",
+                    convert_urls: false,
+                    formats: {
+                      code: {
+                        inline: 'code'
+                      }
+                    },
+                    visual: false,
+                    plugins: "textcolor, link, image, codemirror",
+                    codemirror: {
+                      path: "" + baseUrl + "/js/vendor"
+                    },
+                    image_advtab: true,
+                    toolbar: "formatselect | fontselect | bold italic underline forecolor wrapAsCode | bullist numlist outdent indent blockquote | link unlink image | code",
+                    block_formats: interpolate("%(paragraph)s=p;%(preformatted)s=pre;%(heading3)s=h3;%(heading4)s=h4;%(heading5)s=h5;%(heading6)s=h6", {
+                      paragraph: gettext("Paragraph"),
+                      preformatted: gettext("Preformatted"),
+                      heading3: gettext("Heading 3"),
+                      heading4: gettext("Heading 4"),
+                      heading5: gettext("Heading 5"),
+                      heading6: gettext("Heading 6")
+                    }, true),
+                    width: '100%',
+                    height: '400px',
+                    menubar: false,
+                    statusbar: false,
+                    valid_children: "+body[style]",
+                    valid_elements: "*[*]",
+                    extended_valid_elements: "*[*]",
+                    invalid_elements: "",
                 setup : function(ed) {
                     ed.on('change', fieldChanged);
                 }


### PR DESCRIPTION
This only fixes the line break, does not deal well with the page break. Need to find a way around this. I had to revert all changes because we did not have time to test the new html2pdf library on mobile. This branch improves the wysiwyg editor as well. 